### PR TITLE
Add cluster creation

### DIFF
--- a/dask_ctl/__init__.py
+++ b/dask_ctl/__init__.py
@@ -10,6 +10,7 @@ from .discovery import (
 )
 from .lifecycle import (
     get_cluster,
+    create_cluster,
     scale_cluster,
     delete_cluster,
     list_clusters,

--- a/dask_ctl/cli.py
+++ b/dask_ctl/cli.py
@@ -13,6 +13,7 @@ from .discovery import (
     list_discovery_methods,
 )
 from .lifecycle import (
+    create_cluster,
     scale_cluster,
     delete_cluster,
 )
@@ -39,6 +40,23 @@ def cli():
 def cluster():
     """Cluster commands."""
     pass
+
+
+@cluster.command()
+@click.option("-f", "--spec-file-path")
+def create(spec_file_path):
+    """Create a Dask cluster from a spec file."""
+
+    async def _create():
+        try:
+            cluster = await create_cluster(spec_file_path)
+        except Exception:
+            click.echo("Failed to create cluster.")
+            raise click.Abort()
+        else:
+            click.echo(f"Created cluster {cluster.name}.")
+
+    loop.run_sync(_create)
 
 
 @cluster.command()
@@ -158,8 +176,11 @@ def list_discovery():
     async def _list_discovery():
         dm = list_discovery_methods()
         format_output(
-            ["name", "package", "version", "path"],
-            [[m, dm[m]["package"], dm[m]["version"], dm[m]["path"]] for m in dm],
+            ["name", "package", "version", "path", "enabled"],
+            [
+                [m, dm[m]["package"], dm[m]["version"], dm[m]["path"], dm[m]["enabled"]]
+                for m in dm
+            ],
         )
 
     loop.run_sync(_list_discovery)

--- a/dask_ctl/discovery.py
+++ b/dask_ctl/discovery.py
@@ -35,7 +35,7 @@ def list_discovery_methods() -> Dict[str, Callable]:
     """
     discovery_methods = {}
     for ep in pkg_resources.iter_entry_points(group="dask_cluster_discovery"):
-        with suppress(AttributeError), suppress_output():
+        with suppress(AttributeError, ImportError), suppress_output():
             discovery_methods.update(
                 {
                     ep.name: {
@@ -43,6 +43,7 @@ def list_discovery_methods() -> Dict[str, Callable]:
                         "package": ep.dist.key,
                         "version": ep.dist.version,
                         "path": ep.dist.location,
+                        "enabled": True,  # TODO allow disabling
                     }
                 }
             )

--- a/dask_ctl/spec.py
+++ b/dask_ctl/spec.py
@@ -1,0 +1,20 @@
+import yaml
+
+
+def load_spec(path):
+    with open(path, "r") as fh:
+        spec = yaml.load(fh.read())
+
+    version = spec["version"]
+    if version == 1:
+        return load_v1_spec(spec)
+    else:
+        raise KeyError(f"No such daskctl cluster spec version {version}")
+
+
+def load_v1_spec(spec):
+    cm_module = spec["module"]
+    cm_class = spec["class"]
+    args = spec.get("args", [])
+    kwargs = spec.get("kwargs", {})
+    return cm_module, cm_class, args, kwargs

--- a/dask_ctl/tests/conftest.py
+++ b/dask_ctl/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+import os
+
+
+@pytest.fixture
+def simple_spec_path():
+    return os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "specs", "simple.yaml"
+    )

--- a/dask_ctl/tests/specs/simple.yaml
+++ b/dask_ctl/tests/specs/simple.yaml
@@ -1,0 +1,5 @@
+version: 1
+module: "dask.distributed"
+class: "LocalCluster"
+args: []
+kwargs: {}

--- a/dask_ctl/tests/test_cli.py
+++ b/dask_ctl/tests/test_cli.py
@@ -14,6 +14,11 @@ def test_list():
         assert b"Running" in output
 
 
+def test_create(simple_spec_path):
+    output = check_output(["daskctl", "cluster", "create", "-f", simple_spec_path])
+    assert b"Created" in output
+
+
 def test_autocompletion():
     with LocalCluster(scheduler_port=8786) as _:
         assert len(autocomplete_cluster_names(None, None, "")) == 1

--- a/dask_ctl/tests/test_lifecycle.py
+++ b/dask_ctl/tests/test_lifecycle.py
@@ -1,0 +1,12 @@
+import pytest
+
+from dask.distributed import LocalCluster
+
+from dask_ctl.lifecycle import create_cluster
+
+
+@pytest.mark.asyncio
+async def test_create_cluster(simple_spec_path):
+    cluster = await create_cluster(simple_spec_path)
+
+    assert isinstance(cluster, LocalCluster)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8,11 +8,14 @@ Lifecycle
 
 .. autosummary::
     get_cluster
+    create_cluster
     scale_cluster
     delete_cluster
     list_clusters
 
 .. autofunction:: get_cluster
+
+.. autofunction:: create_cluster
 
 .. autofunction:: scale_cluster
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,6 +39,7 @@ Installation
 
    cli.rst
    api.rst
+   spec.rst
 
 .. toctree::
    :maxdepth: 2

--- a/docs/spec.rst
+++ b/docs/spec.rst
@@ -1,0 +1,40 @@
+Cluster specs
+=============
+
+``dask-ctl`` can create Dask clusters for you from spec files.
+
+These files describe the Python cluster manager which should be used along with any arguments.
+
+.. code-block:: yaml
+
+    # /path/to/spec.yaml
+    version: 1
+    module: "dask.distributed"
+    class: "LocalCluster"
+    args: []
+    kwargs:
+        n_workers: 2
+        threads_per_worker: 1
+        memory_limit: '1GB'
+
+You can then create the cluster from the command line.
+
+.. code-block:: bash
+
+    $ daskctl cluster create -f /path/to/spec.yaml
+
+Or using the Python API.
+
+.. code-block:: python
+
+    from dask_ctl import create_cluster
+
+    cluster = create_cluster("/path/to/spec.yaml")
+
+Both of these examples are equivalent to running the following Python code.
+
+.. code-block:: python
+
+    from dask.distributed import LocalCluster
+
+    cluster = LocalCluster(n_workers=2, threads_per_worker=1, memory_limit='1GB')

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ click
 dask
 distributed
 tornado
+pyyaml


### PR DESCRIPTION
Allows clusters to be created from a spec YAML file, either via the CLI or in Python.

This is useful for storing cluster configs as infrastructure-as-code. It may also be useful within the Dask Labextension or Dask Gateway.

**Spec**

```yaml
# /path/to/spec.yaml
version: 1
module: "dask.distributed"
class: "LocalCluster"
args: []
kwargs:
  n_workers: 2
  threads_per_worker: 1
  memory_limit: '1GB'
```

**Creation**

```console
$ daskctl cluster create -f /path/to/spec.yaml
```

or

```python
from dask_ctl import create_cluster
cluster = create_cluster("/path/to/spec.yaml")
```

Both of these examples are equivalent to running the following Python code.

```python

from dask.distributed import LocalCluster

cluster = LocalCluster(n_workers=2, threads_per_worker=1, memory_limit='1GB')
```

This code was inspired by the [factory code in the Dask Labextension](https://github.com/dask/dask-labextension/blob/d771e0f4834b96ca83c5769fe8585ec523d5321e/dask_labextension/manager.py#L24-L47).