### PR TITLE
Add zeroconf discovery support

### DIFF
--- a/dask_ctl/discovery.py
+++ b/dask_ctl/discovery.py
@@ -29,7 +29,7 @@ def list_discovery_methods() -> Dict[str, Callable]:
         'version': '<package version>',
         'path': '<path to package>'}
     }
-    >>> list(list_discovery_methods())
+    >>> list(list_discovery_methods())  # doctest: +SKIP
     ['proxycluster']
 
     """

--- a/dask_ctl/discovery.py
+++ b/dask_ctl/discovery.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Callable, Dict, AsyncIterator, Tuple
 from contextlib import suppress
 import pkg_resources
@@ -126,4 +127,6 @@ async def discover_clusters(discovery=None) -> AsyncIterator[SpecCluster]:
     """
     async for cluster_name, cluster_class in discover_cluster_names(discovery):
         with suppress(Exception), suppress_output():
-            yield cluster_class.from_name(cluster_name)
+            yield await asyncio.get_running_loop().run_in_executor(
+                None, cluster_class.from_name, cluster_name
+            )

--- a/dask_ctl/lifecycle.py
+++ b/dask_ctl/lifecycle.py
@@ -99,7 +99,7 @@ def get_cluster(name: str) -> Cluster:
     async def _get_cluster():
         async for cluster_name, cluster_class in discover_cluster_names():
             if cluster_name == name:
-                return cluster_class.from_name(name)
+                return await loop.run_in_executor(None, cluster_class.from_name, name)
         raise RuntimeError("No such cluster %s", name)
 
     return loop.run_sync(_get_cluster)
@@ -127,7 +127,10 @@ def scale_cluster(name: str, n_workers: int) -> None:
     async def _scale_cluster():
         async for cluster_name, cluster_class in discover_cluster_names():
             if cluster_name == name:
-                return cluster_class.from_name(name).scale(n_workers)
+                cluster = await loop.run_in_executor(
+                    None, cluster_class.from_name, name
+                )
+                return await loop.run_in_executor(None, cluster.scale, n_workers)
         raise RuntimeError("No such cluster %s", name)
 
     return loop.run_sync(_scale_cluster)
@@ -153,7 +156,10 @@ def delete_cluster(name: str) -> None:
     async def _delete_cluster():
         async for cluster_name, cluster_class in discover_cluster_names():
             if cluster_name == name:
-                return cluster_class.from_name(name).close()
+                cluster = await loop.run_in_executor(
+                    None, cluster_class.from_name, name
+                )
+                return await loop.run_in_executor(None, cluster.close)
         raise RuntimeError("No such cluster %s", name)
 
     return loop.run_sync(_delete_cluster)

--- a/dask_ctl/proxy.py
+++ b/dask_ctl/proxy.py
@@ -1,17 +1,19 @@
 from typing import Callable, AsyncIterator, Tuple
 import asyncio
-import contextlib
 
-import psutil
+from zeroconf import (
+    IPVersion,
+    ServiceInfo,
+    ServiceBrowser,
+    Zeroconf,
+)
 
 from distributed.deploy.cluster import Cluster
 from distributed.core import rpc, Status
-from distributed.client import Client
 from distributed.utils import LoopRunner
 
 
-def gen_name(port):
-    return f"proxycluster-{port}"
+_ZC_SERVICE = "_dask._tcp.local."
 
 
 class ProxyCluster(Cluster):
@@ -52,41 +54,19 @@ class ProxyCluster(Cluster):
         ProxyCluster(proxycluster-8786, 'tcp://localhost:8786', workers=4, threads=12, memory=17.18 GB)
 
         """
-        port = name.split("-")[-1]
-        return cls.from_port(port, loop=loop, asynchronous=asynchronous)
 
-    @classmethod
-    def from_port(
-        cls, port: int, loop: asyncio.BaseEventLoop = None, asynchronous: bool = False
-    ):
-        """Get instance of ``ProxyCluster`` by port.
-
-        Parameters
-        ----------
-        port
-            Localhost port of cluster to get ``ProxyCluster`` for.
-        loop (optional)
-            Existing event loop to use.
-        asynchronous (optional)
-            Start asynchronously. Default ``False``.
-
-        Returns
-        -------
-        ProxyCluster
-            Instance of ProxyCluster.
-
-        Examples
-        --------
-        >>> from dask.distributed import LocalCluster  # doctest: +SKIP
-        >>> cluster = LocalCluster(scheduler_port=81234)  # doctest: +SKIP
-        >>> ProxyCluster.from_port(81234)  # doctest: +SKIP
-        ProxyCluster(proxycluster-81234, 'tcp://localhost:81234', workers=4, threads=12, memory=17.18 GB)
-
-        """
         cluster = cls(asynchronous=asynchronous)
-        cluster.name = gen_name(port)
+        cluster.name = name
 
-        cluster.scheduler_comm = rpc(f"tcp://localhost:{port}")
+        # Get scheduler address via zeroconf
+        zeroconf = Zeroconf(ip_version=IPVersion.V4Only)
+        scheduler = ServiceInfo(_ZC_SERVICE, f"{name}._dask._tcp.local.")
+        if not scheduler.request(zeroconf, 3000):
+            raise RuntimeError("Unable to find cluster")
+        addr = scheduler.parsed_addresses()[0]
+        protocol = scheduler.properties[b"protocol"].decode("utf-8")
+        cluster.scheduler_comm = rpc(f"{protocol}://{addr}:{scheduler.port}")
+        zeroconf.close()
 
         cluster._loop_runner = LoopRunner(loop=loop, asynchronous=asynchronous)
         cluster.loop = cluster._loop_runner.loop
@@ -96,12 +76,6 @@ class ProxyCluster(Cluster):
         cluster.status = Status.starting
         cluster.sync(cluster._start)
         return cluster
-
-    def scale(self, *args, **kwargs):
-        raise TypeError("Scaling of ProxyCluster objects is not supported.")
-
-    def close(self, *args, **kwargs):
-        raise TypeError("Closing of ProxyCluster objects is not supported.")
 
 
 async def discover() -> AsyncIterator[Tuple[str, Callable]]:
@@ -133,33 +107,25 @@ async def discover() -> AsyncIterator[Tuple[str, Callable]]:
     [('proxycluster-8786', dask_ctl.proxy.ProxyCluster)]
 
     """
-    open_ports = {8786}
+    zeroconf = Zeroconf(ip_version=IPVersion.V4Only)
+    browser = ServiceBrowser(
+        zeroconf, [_ZC_SERVICE], handlers=[lambda *args, **kw: None]
+    )
 
-    with contextlib.suppress(
-        psutil.AccessDenied
-    ):  # On macOS this needs to be run as root
-        connections = psutil.net_connections()
-        for connection in connections:
-            if (
-                connection.status == "LISTEN"
-                and connection.family.name == "AF_INET"
-                and connection.laddr.port not in open_ports
-            ):
-                open_ports.add(connection.laddr.port)
+    # ServiceBrowser runs in a thread. Give it a chance to find some schedulers.
+    await asyncio.sleep(0.5)
 
-    async def try_connect(port):
-        with contextlib.suppress(OSError, asyncio.TimeoutError):
-            async with Client(
-                f"tcp://localhost:{port}",
-                asynchronous=True,
-                timeout=1,  # Minimum of 1 for Windows
-            ):
-                return port
-        return
+    schedulers = [
+        x.split(".")[0]
+        for x in zeroconf.cache.names()
+        if x.endswith(_ZC_SERVICE) and x != _ZC_SERVICE
+    ]
 
-    for port in await asyncio.gather(*[try_connect(port) for port in open_ports]):
-        if port:
-            yield (
-                gen_name(port),
-                ProxyCluster,
-            )
+    for scheduler in schedulers:
+        yield (
+            scheduler,
+            ProxyCluster,
+        )
+
+    browser.cancel()
+    zeroconf.close()

--- a/dask_ctl/proxy.py
+++ b/dask_ctl/proxy.py
@@ -4,8 +4,8 @@ import asyncio
 from zeroconf import (
     IPVersion,
     ServiceInfo,
-    ServiceBrowser,
     Zeroconf,
+    ServiceBrowser,
 )
 
 from distributed.deploy.cluster import Cluster

--- a/dask_ctl/tests/test_cli.py
+++ b/dask_ctl/tests/test_cli.py
@@ -21,6 +21,7 @@ def test_create(simple_spec_path):
 
 def test_autocompletion():
     with LocalCluster(scheduler_port=8786) as _:
-        assert len(autocomplete_cluster_names(None, None, "")) == 1
-        assert len(autocomplete_cluster_names(None, None, "_sched")) == 1
+        names = autocomplete_cluster_names(None, None, "")
+        assert len(names) == 1
+        assert "_sched" in names[0]
         assert len(autocomplete_cluster_names(None, None, "local")) == 0

--- a/dask_ctl/tests/test_cli.py
+++ b/dask_ctl/tests/test_cli.py
@@ -22,5 +22,5 @@ def test_create(simple_spec_path):
 def test_autocompletion():
     with LocalCluster(scheduler_port=8786) as _:
         assert len(autocomplete_cluster_names(None, None, "")) == 1
-        assert len(autocomplete_cluster_names(None, None, "proxy")) == 1
+        assert len(autocomplete_cluster_names(None, None, "_sched")) == 1
         assert len(autocomplete_cluster_names(None, None, "local")) == 0

--- a/dask_ctl/tests/test_discovery.py
+++ b/dask_ctl/tests/test_discovery.py
@@ -44,7 +44,7 @@ async def test_discovery_list():
     port = 8786
     async with LocalCluster(scheduler_port=port, asynchronous=True) as _:
         async for name, _ in discover():
-            assert str(port) in name
+            assert "_sched" in name
 
 
 @pytest.mark.asyncio

--- a/dask_ctl/utils.py
+++ b/dask_ctl/utils.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager, redirect_stdout, redirect_stderr
 from io import StringIO
+import os
 
 from tornado.ioloop import IOLoop
 from distributed.cli.utils import install_signal_handlers
@@ -55,5 +56,8 @@ def format_table(rows, headers=None):
 
 @contextmanager
 def suppress_output():
-    with redirect_stdout(StringIO()), redirect_stderr(StringIO()):
+    if "DASK_CTL_DEBUG" in os.environ:
         yield
+    else:
+        with redirect_stdout(StringIO()), redirect_stderr(StringIO()):
+            yield

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ dask
 distributed
 tornado
 pyyaml
+zeroconf>=0.32.0


### PR DESCRIPTION
This PR adds support for discovering clusters via zeroconf announcements (added in dask/distributed#5012). This replaces the current method of discovering local clusters by polling busy ports to see if they are Dask clusters.

This could also be expanded don in the future to support more than `ProxyCluster` provided the scheduler announces it's cluster name and type via zeroconf (related to dask/distributed#5031).