### PR TITLE
update actions so that release depends on tests passing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        python-version: ["3.7", "3.8"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - name: Checkout source

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,12 @@
 name: Build distribution
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - main
+    tags:
+      - "20*" # Push events to matching 20*, i.e. 2022.2.0, 2099.8.1
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,8 @@ name: Build distribution
 on: [push, pull_request]
 
 jobs:
-  test:
+  release:
+    needs: [ test ]
     runs-on: "ubuntu-latest"
 
     steps:


### PR DESCRIPTION
the release action should now depend on tests passing and will only run on tags matching the "20*" wildcard

this *should* work but my github-actions foo isn't super strong and may need a second pass