### PR TITLE
remove coverage argument from pytest addopts config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ tag_prefix =
 parentdir_prefix =
 
 [tool:pytest]
-addopts = --doctest-modules --cov=./ --ignore=docs
+addopts = --doctest-modules --ignore=docs
 
 [flake8]
 exclude = __init__.py,versioneer.py,_version.py


### PR DESCRIPTION
When running pytest locally I get

```sh
(dask-ctl) ➜  dask-ctl git:(main) pytest                    
ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]
pytest: error: unrecognized arguments: --cov=./
  inifile: /Users/aburt/Programming/dask-ctl/setup.cfg
  rootdir: /Users/aburt/Programming/dask-ctl
```

this PR solves the issue for me but might break anything you do with the coverage results

I'm also not sure why this runs on CI/for you but not for me...