### PR TITLE
Make create_cluster sync

### DIFF
--- a/dask_ctl/cli.py
+++ b/dask_ctl/cli.py
@@ -60,16 +60,13 @@ def cluster():
 def create(spec_file_path):
     """Create a Dask cluster from a spec file."""
 
-    async def _create():
-        try:
-            cluster = await create_cluster(spec_file_path)
-        except Exception:
-            click.echo("Failed to create cluster.")
-            raise click.Abort()
-        else:
-            click.echo(f"Created cluster {cluster.name}.")
-
-    loop.run_sync(_create)
+    try:
+        cluster = create_cluster(spec_file_path)
+    except Exception:
+        click.echo("Failed to create cluster.")
+        raise click.Abort()
+    else:
+        click.echo(f"Created cluster {cluster.name}.")
 
 
 @cluster.command()

--- a/dask_ctl/tests/test_lifecycle.py
+++ b/dask_ctl/tests/test_lifecycle.py
@@ -5,7 +5,7 @@ from dask.distributed import LocalCluster, Client
 from dask_ctl.lifecycle import create_cluster, get_snippet
 
 
-async def test_create_cluster(simple_spec_path):
+def test_create_cluster(simple_spec_path):
     cluster = create_cluster(simple_spec_path)
 
     assert isinstance(cluster, LocalCluster)
@@ -13,13 +13,13 @@ async def test_create_cluster(simple_spec_path):
 
 def test_snippet():
     with LocalCluster(scheduler_port=8786) as cluster:
-        client = Client(cluster)
-        client.wait_for_workers(1)
+        with Client(cluster) as client:
+            client.wait_for_workers(1)
 
-        snippet = get_snippet("proxycluster-8786")
+            snippet = get_snippet("proxycluster-8786")
 
-        # Check is valid Python
-        ast.parse(snippet)
+            # Check is valid Python
+            ast.parse(snippet)
 
-        assert "ProxyCluster" in snippet
-        assert "proxycluster-8786" in snippet
+            assert "ProxyCluster" in snippet
+            assert "proxycluster-8786" in snippet

--- a/dask_ctl/tests/test_lifecycle.py
+++ b/dask_ctl/tests/test_lifecycle.py
@@ -13,7 +13,7 @@ def test_create_cluster(simple_spec_path):
     assert isinstance(cluster, LocalCluster)
 
 
-@pytest.xfail(
+@pytest.mark.xfail(
     "GitHib Actions seems to intermittently have port 8786 in use causing this test to fail."
 )
 def test_snippet():

--- a/dask_ctl/tests/test_lifecycle.py
+++ b/dask_ctl/tests/test_lifecycle.py
@@ -1,6 +1,8 @@
+import pytest
+
 import ast
 
-from dask.distributed import LocalCluster, Client
+from dask.distributed import LocalCluster
 
 from dask_ctl.lifecycle import create_cluster, get_snippet
 
@@ -11,15 +13,15 @@ def test_create_cluster(simple_spec_path):
     assert isinstance(cluster, LocalCluster)
 
 
+@pytest.xfail(
+    "GitHib Actions seems to intermittently have port 8786 in use causing this test to fail."
+)
 def test_snippet():
-    with LocalCluster(scheduler_port=8786) as cluster:
-        with Client(cluster) as client:
-            client.wait_for_workers(1)
+    with LocalCluster(scheduler_port=8786) as _:
+        snippet = get_snippet("proxycluster-8786")
 
-            snippet = get_snippet("proxycluster-8786")
+        # Check is valid Python
+        ast.parse(snippet)
 
-            # Check is valid Python
-            ast.parse(snippet)
-
-            assert "ProxyCluster" in snippet
-            assert "proxycluster-8786" in snippet
+        assert "ProxyCluster" in snippet
+        assert "proxycluster-8786" in snippet

--- a/dask_ctl/tests/test_lifecycle.py
+++ b/dask_ctl/tests/test_lifecycle.py
@@ -14,7 +14,7 @@ def test_create_cluster(simple_spec_path):
 
 
 @pytest.mark.xfail(
-    "GitHib Actions seems to intermittently have port 8786 in use causing this test to fail."
+    reason="GitHib Actions seems to intermittently have port 8786 in use causing this test to fail."
 )
 def test_snippet():
     with LocalCluster(scheduler_port=8786) as _:

--- a/dask_ctl/tests/test_lifecycle.py
+++ b/dask_ctl/tests/test_lifecycle.py
@@ -1,6 +1,6 @@
 import ast
 
-from dask.distributed import LocalCluster
+from dask.distributed import LocalCluster, Client
 
 from dask_ctl.lifecycle import create_cluster, get_snippet
 
@@ -12,7 +12,10 @@ async def test_create_cluster(simple_spec_path):
 
 
 def test_snippet():
-    with LocalCluster(scheduler_port=8786) as _:
+    with LocalCluster(scheduler_port=8786) as cluster:
+        client = Client(cluster)
+        client.wait_for_workers(1)
+
         snippet = get_snippet("proxycluster-8786")
 
         # Check is valid Python

--- a/dask_ctl/tests/test_lifecycle.py
+++ b/dask_ctl/tests/test_lifecycle.py
@@ -1,5 +1,3 @@
-import pytest
-
 import ast
 
 from dask.distributed import LocalCluster
@@ -7,9 +5,8 @@ from dask.distributed import LocalCluster
 from dask_ctl.lifecycle import create_cluster, get_snippet
 
 
-@pytest.mark.asyncio
 async def test_create_cluster(simple_spec_path):
-    cluster = await create_cluster(simple_spec_path)
+    cluster = create_cluster(simple_spec_path)
 
     assert isinstance(cluster, LocalCluster)
 

--- a/dask_ctl/tests/test_lifecycle.py
+++ b/dask_ctl/tests/test_lifecycle.py
@@ -1,5 +1,3 @@
-import pytest
-
 import ast
 
 from dask.distributed import LocalCluster
@@ -13,9 +11,6 @@ def test_create_cluster(simple_spec_path):
     assert isinstance(cluster, LocalCluster)
 
 
-@pytest.mark.xfail(
-    reason="GitHib Actions seems to intermittently have port 8786 in use causing this test to fail."
-)
 def test_snippet():
     with LocalCluster(scheduler_port=8786) as _:
         snippet = get_snippet("proxycluster-8786")


### PR DESCRIPTION
Closes #30.

Everything in `dask_ctl.lifecycle` is an async function wrapped in a sync function except for `create_cluster`. Make it consistent.