### PR TITLE
Try pinning pytest-asyncio version

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,3 @@
 pytest
-pytest-asyncio
+pytest-asyncio==0.15.1
 pytest-cov


### PR DESCRIPTION
Exploring a fix for #28.

The issue seems to be with asyncio support in pytest.

I am unable to reproduce the CI errors locally, but @alisterburt has been able to. Looking at my local environment my `pytest-asyncio` version is `0.15.1` which is behind the current `0.17.2`. 

I'll start by pinning to see if that resolves things before moving to a more permanent fix.