### PR TITLE
silence a deprecation

### DIFF
--- a/dask_ctl/cli.py
+++ b/dask_ctl/cli.py
@@ -12,7 +12,7 @@ from rich.progress import Progress, BarColumn
 from dask.utils import format_bytes, format_time_ago
 from distributed.core import Status
 from distributed.cli.utils import check_python_3
-from distributed.utils import typename
+from dask.utils import typename
 
 from . import __version__
 from .utils import loop

--- a/dask_ctl/cli.py
+++ b/dask_ctl/cli.py
@@ -11,7 +11,6 @@ from rich.progress import Progress, BarColumn
 
 from dask.utils import format_bytes, format_time_ago
 from distributed.core import Status
-from distributed.cli.utils import check_python_3
 from dask.utils import typename
 
 from . import __version__
@@ -327,7 +326,6 @@ def version():
 
 
 def daskctl():
-    check_python_3()
     cli()
 
 


### PR DESCRIPTION
Unlike the import in `dask_ctl.lifecycle`, `dask_ctl.cli` still imports `distributed.utils.typename`.