### PR TITLE
Rename deprecated autocompletion kwarg to shell_complete

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3

--- a/dask_ctl/cli.py
+++ b/dask_ctl/cli.py
@@ -11,7 +11,6 @@ from rich.progress import Progress, BarColumn
 
 from dask.utils import format_bytes, format_time_ago
 from distributed.core import Status
-from distributed.cli.utils import check_python_3
 from distributed.utils import typename
 
 from . import __version__
@@ -327,7 +326,6 @@ def version():
 
 
 def daskctl():
-    check_python_3()
     cli()
 
 

--- a/dask_ctl/cli.py
+++ b/dask_ctl/cli.py
@@ -153,7 +153,7 @@ def list(discovery=None):
 
 
 @cluster.command()
-@click.argument("name", autocompletion=autocomplete_cluster_names)
+@click.argument("name", shell_complete=autocomplete_cluster_names)
 @click.argument("n-workers", type=int)
 def scale(name, n_workers):
     """Scale a Dask cluster.
@@ -219,7 +219,7 @@ def scale(name, n_workers):
 
 
 @cluster.command()
-@click.argument("name", autocompletion=autocomplete_cluster_names)
+@click.argument("name", shell_complete=autocomplete_cluster_names)
 def delete(
     name,
 ):
@@ -239,7 +239,7 @@ def delete(
 
 
 @cluster.command()
-@click.argument("name", autocompletion=autocomplete_cluster_names)
+@click.argument("name", shell_complete=autocomplete_cluster_names)
 def snippet(
     name,
 ):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-click>=8.1
+click>=8.1.2
 dask>=2021.08.1
 distributed
 rich

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-click>=8
+click>=8.1
 dask>=2021.08.1
 distributed
 rich

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-click
+click>=8
 dask>=2021.08.1
 distributed
 rich


### PR DESCRIPTION
In `8.0.0` of Click `autocompletion` was deprecated and renamed to `shell_complete`. In `8.1.0` this deprecation was dropped.

This PR fixes things by switching to the new syntax.