### PR TITLE
Allow users to use lifecycle methods both sync and async

### DIFF
--- a/dask_ctl/asyncio.py
+++ b/dask_ctl/asyncio.py
@@ -1,0 +1,6 @@
+from .lifecycle import _create_cluster as create_cluster  # noqa
+from .lifecycle import _list_clusters as list_clusters  # noqa
+from .lifecycle import _get_cluster as get_cluster  # noqa
+from .lifecycle import _get_snippet as get_snippet  # noqa
+from .lifecycle import _scale_cluster as scale_cluster  # noqa
+from .lifecycle import _delete_cluster as delete_cluster  # noqa

--- a/dask_ctl/lifecycle.py
+++ b/dask_ctl/lifecycle.py
@@ -38,18 +38,22 @@ def create_cluster(spec_path: str) -> Cluster:
 
     """
 
-    async def _create_cluster():
-        cm_module, cm_class, args, kwargs = load_spec(spec_path)
-        module = importlib.import_module(cm_module)
-        cluster_manager = getattr(module, cm_class)
+    return loop.run_sync(_create_cluster, spec_path)
 
-        kwargs = {key.replace("-", "_"): entry for key, entry in kwargs.items()}
 
-        cluster = await cluster_manager(*args, **kwargs, asynchronous=True)
-        cluster.shutdown_on_close = False
-        return cluster
+async def _create_cluster(spec_path: str) -> Cluster:
+    cm_module, cm_class, args, kwargs = load_spec(spec_path)
+    module = importlib.import_module(cm_module)
+    cluster_manager = getattr(module, cm_class)
 
-    return loop.run_sync(_create_cluster)
+    kwargs = {key.replace("-", "_"): entry for key, entry in kwargs.items()}
+
+    cluster = await cluster_manager(*args, **kwargs, asynchronous=True)
+    cluster.shutdown_on_close = False
+    return cluster
+
+
+_create_cluster.__doc__ = create_cluster.__doc__
 
 
 def list_clusters() -> List[Cluster]:
@@ -71,13 +75,17 @@ def list_clusters() -> List[Cluster]:
 
     """
 
-    async def _list_clusters():
-        clusters = []
-        async for cluster in discover_clusters():
-            clusters.append(cluster)
-        return clusters
-
     return loop.run_sync(_list_clusters)
+
+
+async def _list_clusters() -> List[Cluster]:
+    clusters = []
+    async for cluster in discover_clusters():
+        clusters.append(cluster)
+    return clusters
+
+
+_list_clusters.__doc__ = list_clusters.__doc__
 
 
 def get_cluster(name: str) -> Cluster:
@@ -102,13 +110,17 @@ def get_cluster(name: str) -> Cluster:
 
     """
 
-    async def _get_cluster():
-        async for cluster_name, cluster_class in discover_cluster_names():
-            if cluster_name == name:
-                return cluster_class.from_name(name)
-        raise RuntimeError("No such cluster %s", name)
+    return loop.run_sync(_get_cluster, name)
 
-    return loop.run_sync(_get_cluster)
+
+async def _get_cluster(name: str) -> Cluster:
+    async for cluster_name, cluster_class in discover_cluster_names():
+        if cluster_name == name:
+            return cluster_class.from_name(name)
+    raise RuntimeError("No such cluster %s", name)
+
+
+_get_cluster.__doc__ = get_cluster.__doc__
 
 
 def get_snippet(name: str) -> str:
@@ -136,8 +148,11 @@ def get_snippet(name: str) -> str:
     client = Client(cluster)
 
     """
+    return loop.run_sync(_get_snippet, name)
 
-    cluster = get_cluster(name)
+
+async def _get_snippet(name: str) -> str:
+    cluster = await _get_cluster(name)
     try:
         return cluster.get_snippet()
     except AttributeError:
@@ -146,6 +161,9 @@ def get_snippet(name: str) -> str:
         return get_template("snippet.py.j2").render(
             module=module, cm=cm, name=name, cluster=cluster
         )
+
+
+_get_snippet.__doc__ = get_snippet.__doc__
 
 
 def scale_cluster(name: str, n_workers: int) -> None:
@@ -166,8 +184,15 @@ def scale_cluster(name: str, n_workers: int) -> None:
     >>> scale_cluster("mycluster", 10)  # doctest: +SKIP
 
     """
+    return loop.run_sync(_scale_cluster, name, n_workers)
 
-    return get_cluster(name).scale(n_workers)
+
+async def _scale_cluster(name: str, n_workers: int) -> None:
+    cluster = await _get_cluster(name)
+    return await cluster.scale(n_workers)
+
+
+_scale_cluster.__doc__ = scale_cluster.__doc__
 
 
 def delete_cluster(name: str) -> None:
@@ -186,5 +211,12 @@ def delete_cluster(name: str) -> None:
     >>> delete_cluster("mycluster")  # doctest: +SKIP
 
     """
+    return loop.run_sync(_delete_cluster, name)
 
-    return get_cluster(name).close()
+
+async def _delete_cluster(name: str) -> None:
+    cluster = await _get_cluster(name)
+    return await cluster.close()
+
+
+_delete_cluster.__doc__ = _delete_cluster.__doc__

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6,6 +6,25 @@ Python API
 Lifecycle
 ---------
 
+Dask Control has a selection of lifecycle functions that can be used within Python to manage
+your Dask clusters. You can list clusters, get instances of an existing cluster, create new ones, scale and delete them.
+
+You can either use these in a regular synchronous way by importing them from ``dask_ctl``.
+
+.. code-block:: python
+
+      from dask_ctl import list_clusters
+
+      clusters = list_clusters()
+
+Or alternatively you can use them in async code by importing from the ``dask_ctl.asyncio`` submodule.
+
+.. code-block:: python
+
+      from dask_ctl.asyncio import list_clusters
+
+      clusters = await list_clusters()
+
 .. autosummary::
     get_cluster
     create_cluster


### PR DESCRIPTION
Dask Control has a selection of lifecycle functions that can be used within Python to manage
your Dask clusters. You can list clusters, get instances of an existing cluster, create new ones, scale and delete them.

Currently these methods are implemented as async closures within a sync function that starts the loop. This PR breaks things out so that users can choose to import the async method directly from the `dask_ctl.asyncio` submodule or choose to use the sync version from `dask_ctl`. 

**Sync**

```python
from dask_ctl import list_clusters

clusters = list_clusters()
```

**Async**

```python
 from dask_ctl.asyncio import list_clusters

clusters = await list_clusters()
```