### PR TITLE
Remove signal handlers

### DIFF
--- a/dask_ctl/utils.py
+++ b/dask_ctl/utils.py
@@ -1,11 +1,9 @@
 import asyncio
 
 from tornado.ioloop import IOLoop
-from distributed.cli.utils import install_signal_handlers
 
 
 loop = IOLoop.current()
-install_signal_handlers(loop)
 
 
 class _AsyncTimedIterator:


### PR DESCRIPTION
Looks like the `install_signal_handlers` function has been removed upstream in dask/dask-kubernetes/pull/493. This has broken `dask-ctl`.

Trying just dropping it.