### PR TITLE
Update docs theme

### DIFF
--- a/docs/requirements_docs.txt
+++ b/docs/requirements_docs.txt
@@ -1,4 +1,4 @@
 sphinx
 sphinx-autobuild
 sphinx-click
-dask-sphinx-theme
+dask-sphinx-theme>=3.0.0


### PR DESCRIPTION
Dask.org has gone live with a new design (see https://github.com/dask/community/issues/220). This PR is to update the `dask-sphinx-theme` (see https://github.com/dask/dask-sphinx-theme/pull/67)

cc @jacobtomlinson @jsignell