### PR TITLE
Add demo app to logo file

### DIFF
--- a/dask_ctl/tui/widgets/logo.py
+++ b/dask_ctl/tui/widgets/logo.py
@@ -1,4 +1,7 @@
 from rich.text import Text
+
+from textual import events
+from textual.app import App
 from textual.widget import Widget
 
 
@@ -16,3 +19,18 @@ class Logo(Widget):
         A╨\"""",
             style="orange3",
         )
+
+
+class Demo(App):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    async def on_load(self, event: events.Load) -> None:
+        await self.bind("q", "quit", "Quit")
+
+    async def on_mount(self, event: events.Mount) -> None:
+        await self.view.dock(Logo(), edge="top")
+
+
+if __name__ == "__main__":
+    Demo.run(title="Logo", log="textual.log")


### PR DESCRIPTION
If you run `python dask_ctl/tui/widgets/logo.py` it will open the logo widget inside an empty textual app. Nice for manual testing.