### PR TITLE
Fix bars demo

### DIFF
--- a/dask_ctl/tui/graphs/bar.py
+++ b/dask_ctl/tui/graphs/bar.py
@@ -92,7 +92,7 @@ class HBar:
             value_text = f" {self.formatter(value)}"
             try:
                 bar_width = floor(
-                    ((max_width / self.x_width or max(self.data.values())) * value)
+                    ((max_width / (self.x_width or max(self.data.values()))) * value)
                 )
             except ZeroDivisionError:
                 bar_width = 0


### PR DESCRIPTION
To view the bars demo you can run `python dask_ctl/tui/graphs/bar.py` but it seemed to be broken due to some missing brackets.