### PR TITLE
Make snippet simpler

### DIFF
--- a/dask_ctl/tests/test_lifecycle.py
+++ b/dask_ctl/tests/test_lifecycle.py
@@ -18,5 +18,4 @@ def test_snippet():
         # Check is valid Python
         ast.parse(snippet)
 
-        assert "ProxyCluster" in snippet
         assert "proxycluster-8786" in snippet

--- a/dask_ctl/widgets/templates/snippet.py.j2
+++ b/dask_ctl/widgets/templates/snippet.py.j2
@@ -1,5 +1,5 @@
 from dask.distributed import Client
-from {{ module }} import {{ cm }}
+from dask_ctl import get_cluster
 
-cluster = {{ cm }}.from_name("{{ name }}")
+cluster = get_cluster("{{ name }}")
 client = Client(cluster)


### PR DESCRIPTION
Now that `get_cluster` exists users shouldn't ever have to directly call `from_name`. Updating the snippet with the newer syntax.