### PR TITLE
Use textual focus

### DIFF
--- a/dask_ctl/tui/widgets/cluster_table.py
+++ b/dask_ctl/tui/widgets/cluster_table.py
@@ -13,7 +13,7 @@ from textual.message import Message, MessageTarget
 from ...renderables import generate_table
 
 
-class ClusterTable(Widget):
+class ClusterTable(Widget, can_focus=True):
 
     selected = reactive(0)
     table = reactive(Table())
@@ -34,7 +34,6 @@ class ClusterTable(Widget):
         return list(self.table.columns[0].cells)[self.selected]
 
     async def reload_table(self):
-        self.log("Reloaded cluster table")
         self.table = await generate_table()
         self.table.expand = True
         self.table.style = "white"


### PR DESCRIPTION
Figured out how to use textual's focus properly instead of faking it with forwarding key presses.

The cluster table and command prompt are now focusable. The app focuses the table on mount and the user can switch focus to the command prompt by clicking or hitting `:`. They can return the focus to the table by pressing `escape` or submitting a command with `enter`.