### PR TITLE
Hook up --debug flag to textual console

### DIFF
--- a/dask_ctl/cli.py
+++ b/dask_ctl/cli.py
@@ -1,3 +1,4 @@
+import os
 from time import sleep
 import sys
 import warnings
@@ -280,11 +281,16 @@ def version():
 @click.option("--debug/--no-debug", default=False)
 def ui(debug):
     """Open the Dask Control Text UI."""
-    if DaskCtlTUI is None:
-        click.echo("Error: Textual is not supported on your system. Sorry!")
-        raise click.Abort()
-    else:
-        DaskCtlTUI().run()
+    from textual.features import parse_features
+
+    features = set(parse_features(os.environ.get("TEXTUAL", "")))
+    if debug:
+        features.add("debug")
+        features.add("devtools")
+
+    os.environ["TEXTUAL"] = ",".join(sorted(features))
+
+    DaskCtlTUI().run()
 
 
 def daskctl():


### PR DESCRIPTION
For debugging I've been running the TUI with the `textual` command in `--dev` mode to hook it up to the `textual console`.

```console
$ textual run --dev dask_ctl.tui:DaskCtlTUI
```

This PR makes the `--debug` flag on `dask cluster ui` effectively do the same thing.

```console
$ dask cluster ui --debug
```

This means you can start the TUI the same way as users when developing but still get the useful debug info.