### PR TITLE
Move bindings onto widgets

### DIFF
--- a/dask_ctl/tui/widgets/cluster_table.py
+++ b/dask_ctl/tui/widgets/cluster_table.py
@@ -8,6 +8,7 @@ from textual import events
 from textual.reactive import reactive
 from textual.widget import Widget
 from textual.message import Message, MessageTarget
+from textual.binding import Binding
 
 
 from ...renderables import generate_table
@@ -15,9 +16,40 @@ from ...renderables import generate_table
 
 class ClusterTable(Widget, can_focus=True):
 
+    BINDINGS = [
+        Binding("q", "graceful_quit()", "Quit"),
+        Binding("r", "refresh()", "Refresh list"),
+        Binding("s", "set_scale_prompt()", "Scale cluster"),
+        Binding("c", "set_close_prompt()", "Close cluster"),
+        Binding("colon", "focus_prompt()", "New Command", key_display=":"),
+    ]
+
     selected = reactive(0)
     table = reactive(Table())
     update_interval = None
+
+    class FocusPrompt(Message):
+        """Focus Prompt message."""
+
+    class GracefulQuit(Message):
+        """Graceful Quit message."""
+
+    class Refresh(Message):
+        """Refresh message."""
+
+    class SetScalePrompt(Message):
+        """Set Scale Prompt message."""
+
+        def __init__(self, sender: MessageTarget, cluster: str) -> None:
+            self.cluster = cluster
+            super().__init__(sender)
+
+    class SetClosePrompt(Message):
+        """Set Close Prompt message."""
+
+        def __init__(self, sender: MessageTarget, cluster: str) -> None:
+            self.cluster = cluster
+            super().__init__(sender)
 
     class ClusterSelected(Message):
         """Cluster selected message."""
@@ -32,6 +64,21 @@ class ClusterTable(Widget, can_focus=True):
     @property
     def selected_cluster(self):
         return list(self.table.columns[0].cells)[self.selected]
+
+    async def action_graceful_quit(self) -> None:
+        await self.emit(self.GracefulQuit(self))
+
+    async def action_refresh(self):
+        await self.emit(self.Refresh(self))
+
+    async def action_set_scale_prompt(self) -> None:
+        await self.emit(self.SetScalePrompt(self, self.selected_cluster))
+
+    async def action_set_close_prompt(self) -> None:
+        await self.emit(self.SetClosePrompt(self, self.selected_cluster))
+
+    async def action_focus_prompt(self):
+        await self.emit(self.FocusPrompt(self))
 
     async def reload_table(self):
         self.table = await generate_table()

--- a/dask_ctl/tui/widgets/key_bindings.py
+++ b/dask_ctl/tui/widgets/key_bindings.py
@@ -1,12 +1,25 @@
 from rich.text import Text
 
+from textual.reactive import watch, reactive
 from textual.widget import Widget
 
 
 class KeyBindings(Widget):
+
+    bindings = reactive([])
+
+    def on_mount(self) -> None:
+        watch(self.screen, "focused", self._focus_changed)
+
+    def _focus_changed(self, focused) -> None:
+        self.bindings = [*self.app.BINDINGS]
+        if focused:
+            self.bindings += focused.BINDINGS
+        self.refresh()
+
     def render(self) -> Text:
         outs = [("Key bindings", "bold"), "\n"]
-        for binding in self.app.BINDINGS:
+        for binding in self.bindings:
             try:
                 key, _, description = binding
             except TypeError:


### PR DESCRIPTION
Instead of having all the bindings on the TUI app I've moved them down onto the appropriate widgets.

The cluster table has most bindings. When bindings are pressed the table emits an event and the app takes action.

The command prompt has just the `escape` binding for exiting command mode.

This refactor means I could remove all the focus-checking logic from bindings so that when the user typed `q` in the prompt it didn't quit. Now `q` is just bound to the cluster table and not the command prompt.