### PR TITLE
Create default fallback

### DIFF
--- a/dask_ctl/__init__.py
+++ b/dask_ctl/__init__.py
@@ -1,5 +1,5 @@
 from ._version import get_versions
-
+from .exceptions import DaskClusterConfigNotFound  # noqa
 import os.path
 
 from dask.widgets import TEMPLATE_PATHS

--- a/dask_ctl/ctl.yaml
+++ b/dask_ctl/ctl.yaml
@@ -1,2 +1,3 @@
 ctl:
   disable_discovery: []
+  cluster-spec: null

--- a/dask_ctl/exceptions.py
+++ b/dask_ctl/exceptions.py
@@ -1,0 +1,2 @@
+class DaskClusterConfigNotFound(FileNotFoundError):
+    """Unable to find the Dask cluster config."""

--- a/dask_ctl/lifecycle.py
+++ b/dask_ctl/lifecycle.py
@@ -1,6 +1,7 @@
 import importlib
 from typing import List
 
+import dask.config
 from dask.widgets import get_template
 from dask.utils import typename
 from distributed.deploy import LocalCluster
@@ -12,7 +13,7 @@ from .exceptions import DaskClusterConfigNotFound
 
 
 def create_cluster(
-    spec_path: str = "dask-cluster.yaml",
+    spec_path: str = None,
     local_fallback: bool = False,
     asynchronous: bool = False,
 ) -> Cluster:
@@ -47,6 +48,10 @@ def create_cluster(
     LocalCluster(b3973c71, 'tcp://127.0.0.1:8786', workers=4, threads=12, memory=17.18 GB)
 
     """
+    spec_path = (
+        dask.config.get("ctl.cluster-spec", None, override_with=spec_path)
+        or "dask-cluster.yaml"
+    )
 
     async def _create_cluster():
         try:

--- a/dask_ctl/tests/test_lifecycle.py
+++ b/dask_ctl/tests/test_lifecycle.py
@@ -1,6 +1,7 @@
 import pytest
 import ast
 
+import dask.config
 from dask.distributed import LocalCluster
 
 from dask_ctl.lifecycle import create_cluster, get_snippet
@@ -14,8 +15,12 @@ def test_create_cluster(simple_spec_path):
 
 
 def test_create_cluster_fallback():
-    with pytest.raises(DaskClusterConfigNotFound):
+    with pytest.raises(DaskClusterConfigNotFound, match="dask-cluster.yaml"):
         cluster = create_cluster()
+
+    with dask.config.set({"ctl.cluster-spec": "foo.yaml"}):
+        with pytest.raises(DaskClusterConfigNotFound, match="foo.yaml"):
+            cluster = create_cluster()
 
     cluster = create_cluster(local_fallback=True)
     assert isinstance(cluster, LocalCluster)

--- a/dask_ctl/tests/test_lifecycle.py
+++ b/dask_ctl/tests/test_lifecycle.py
@@ -4,11 +4,20 @@ import ast
 from dask.distributed import LocalCluster
 
 from dask_ctl.lifecycle import create_cluster, get_snippet
+from dask_ctl.exceptions import DaskClusterConfigNotFound
 
 
 def test_create_cluster(simple_spec_path):
     cluster = create_cluster(simple_spec_path)
 
+    assert isinstance(cluster, LocalCluster)
+
+
+def test_create_cluster_fallback():
+    with pytest.raises(DaskClusterConfigNotFound):
+        cluster = create_cluster()
+
+    cluster = create_cluster(local_fallback=True)
     assert isinstance(cluster, LocalCluster)
 
 


### PR DESCRIPTION
Added a default lookup location for `create_cluster()`. If you fail to specify the path to a valid spec it will try and find it at `dask-cluster.yaml`.

```python
>>> import dask_ctl.lifecycle
>>> dask_ctl.lifecycle.create_cluster()
DaskClusterConfigNotFound: Unable to find dask-cluster.yaml
```

You can also set the `local_fallback=True` option to start a `LocalCluster` if a spec file is not found.

```python
>>> import dask_ctl.lifecycle
>>> dask_ctl.lifecycle.create_cluster(local_fallback=True)
LocalCluster(3ce576d4, 'tcp://127.0.0.1:8787', workers=4, threads=12, memory=93.02 GiB)
```